### PR TITLE
keep `n_init` parameters for kmeans

### DIFF
--- a/mddatasetbuilder/datasetbuilder.py
+++ b/mddatasetbuilder/datasetbuilder.py
@@ -358,7 +358,7 @@ class DatasetBuilder:
         min_max_scaler = preprocessing.MinMaxScaler()
         X = np.array(min_max_scaler.fit_transform(X))
         clus = MiniBatchKMeans(
-            n_clusters=n_clusters, init_size=(min(3 * n_clusters, len(X)))
+            n_clusters=n_clusters, init_size=(min(3 * n_clusters, len(X))), n_init=3
         )
         labels = clus.fit_predict(X)
         choosedidx = []


### PR DESCRIPTION
See https://github.com/scikit-learn/scikit-learn/commit/0d923daf6ddbf1afc0915a145955cfff97505f51. It's unclear how this change will affect the results, so keeping the behavior is better.